### PR TITLE
Extend start and destination possible values

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ sensor:
 key | type | description  
 :--- | :--- | :---  
 **platform (Required)** | string | The platform name.
-**start (Required)** | string | Entity ID of a device_tracker with `latitude` and `longitude` attributes, or GPS coordinates like `'29.361133,54.991133'`
-**destination (Required)** | string | GPS coordinates like `'29.361133,54.991133'`.
+**start (Required)** | string | Entity ID of a device_tracker or zone with `latitude` and `longitude` attributes, or GPS coordinates like `'29.361133,54.991133'`.
+**destination (Required)** | string | Entity ID of a device_tracker or zone with `latitude` and `longitude` attributes, or GPS coordinates like `'29.361133,54.991133'`.
 **name (Required)** | string | Name of the sensor.
 
 ***

--- a/custom_components/yandex_maps/sensor.py
+++ b/custom_components/yandex_maps/sensor.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 
-__version__ = '0.0.4'
+__version__ = '0.0.5'
 
 CONF_NAME = 'name'
 CONF_START = 'start'

--- a/custom_components/yandex_maps/sensor.py
+++ b/custom_components/yandex_maps/sensor.py
@@ -5,7 +5,8 @@ For more details about this component, please refer to the documentation at
 https://github.com/custom-components/sensor.yandex_maps
 """
 import logging
-import requests
+
+import aiohttp
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -40,8 +41,10 @@ async def async_setup_platform(
     async_add_entities(
         [YandexMapsSensor(hass, name, start, destination)], True)
 
+
 class YandexMapsSensor(Entity):
     """YandexMap Sensor class"""
+
     def __init__(self, hass, name, start, destination):
         self.hass = hass
         self._state = None
@@ -49,31 +52,49 @@ class YandexMapsSensor(Entity):
         self._start = start
         self._destination = destination
         self.attr = {}
+        _LOGGER.debug('Initialized sensor %s with %s, %s', self._name, self._start, self._destination)
 
     async def async_update(self):
         """Update sensor."""
         _LOGGER.debug('%s - Running update', self._name)
-        start = None
-        if 'device_tracker' in self._start:
-            state = self.hass.states.get(self._start)
+
+        try:
+            url = BASE_URL.format(self.start, self.destination)
+
+            _LOGGER.debug('Requesting url %s', url)
+            async with aiohttp.ClientSession() as client:
+                async with client.get(url) as resp:
+                    assert resp.status == 200
+                    info = await resp.json()
+
+                    self._state = info.get('direct', {}).get('time')
+                    self.attr = {
+                        'mapurl': info.get('direct', {}).get('mapUrl'),
+                        'jamsrate': info.get('jamsRate'),
+                        'jamsmeasure': info.get('jamsMeasure')
+                    }
+        except Exception as error:  # pylint: disable=broad-except
+            _LOGGER.debug('%s - Could not update - %s', self._name, error)
+
+    @property
+    def start(self):
+        return self.point_to_coords(self._start)
+
+    @property
+    def destination(self):
+        return self.point_to_coords(self._destination)
+
+    def point_to_coords(self, point):
+        if 'device_tracker' in point or 'zone' in point:
+            state = self.hass.states.get(point)
             if state:
                 latitude = state.attributes.get('latitude')
                 longitude = state.attributes.get('longitude')
                 if latitude and longitude:
-                    start = "{},{}".format(str(longitude), str(latitude))
-        if start is None:
-            start = self._start
-        try:
-            url = BASE_URL.format(start, self._destination)
-            info = requests.get(url).json()
-            self._state = info.get('direct', {}).get('time')
-            self.attr = {
-                'mapurl': info.get('direct', {}).get('mapUrl'),
-                'jamsrate': info.get('jamsRate'),
-                'jamsmeasure': info.get('jamsMeasure')
-            }
-        except Exception as error:  # pylint: disable=broad-except
-            _LOGGER.debug('%s - Could not update - %s', self._name, error)
+                    return "{},{}".format(longitude, latitude)
+                else:
+                    raise AttributeError
+        return point
 
     @property
     def name(self):


### PR DESCRIPTION
Now it is possible to configure both sensor's `start` and `destination` either raw coords, device_tracker entity or zone entity.

For example, I add two sensors: 
* my phone device tracker to my work zone 
* my phone device tracker to my home zone.

```yaml
sensor:
  - platform: yandex_maps
    start: 'device_tracker.mikhails_iphone'
    destination: 'zone.home'
    name: Time to home
  - platform: yandex_maps
    start: 'zone.home'
    destination: 'zone.work'
```

And it is more helpful for me now

![image](https://user-images.githubusercontent.com/430023/61169054-27854680-a560-11e9-89a4-7ccdcce6753c.png)
