### PR TITLE
Rename device_state_attributes -> extra_state_attributes

### DIFF
--- a/custom_components/yandex_maps/sensor.py
+++ b/custom_components/yandex_maps/sensor.py
@@ -126,6 +126,6 @@ class YandexMapsSensor(Entity):
         return 'мин'
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Attributes."""
         return self.attr


### PR DESCRIPTION
In logs found this issue:
```Entity sensor.time_to_simplex (<class 'custom_components.yandex_maps.sensor.YandexMapsSensor'>) implements device_state_attributes. Please report it to the custom component author.```
Fixes #19 